### PR TITLE
[MIR-32] Add crt0.o for linux-x86_64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15.0)
 
-project(mirlib LANGUAGES C)
+project(mirlib LANGUAGES ASM C)
 
 set(SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/mir)
 set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
@@ -22,3 +22,28 @@ endif()
 if(MIR_NDEBUG)
   target_compile_definitions(mir PUBLIC MIR_NDEBUG)
 endif()
+
+if(MIR_BUILD_CRT0)
+  message(WARNING "`MIR_BUILD_CRT0' option is highly experimental")
+
+  if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+    if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
+      add_library(crt0 OBJECT src/mir/rt/linux/x86_64/crt0.S)
+    else()
+      message(
+        SEND_ERROR "`MIR_BUILD_CRT0' option does not supported for this arch")
+    endif() # CMAKE_SYSTEM_PROCESSOR
+  else()
+    message(SEND_ERROR "`MIR_BUILD_CRT0' option does not supported for this OS")
+  endif() # CMAKE_SYSTEM_NAME
+
+  # FIXME: seems like `PREFIX`, `OUTPUT_NAME`, and `SUFFIX` don't work with
+  #        Object Libraries. The resulting name should be `crt0.o` not
+  #        `crt0.S.o`
+  set_target_properties(
+    crt0
+    PROPERTIES PREFIX ""
+               OUTPUT_NAME "crt0"
+               SUFFIX ".o")
+
+endif() # MIR_BUILD_CRT0

--- a/src/mir/rt/linux/x86_64/crt0.S
+++ b/src/mir/rt/linux/x86_64/crt0.S
@@ -1,0 +1,51 @@
+.extern _c_start
+
+.globl _start
+
+.text
+
+/*
+ * \brief Simple `start` routine.
+ *
+ * \warning After `_c_start` function finishes, it immediately syscalls `exit`
+ * with the result of `_c_start` function without any additional actions (e.g.
+ * crt requires to call functions passed to `atexit` before terminating the
+ * process).
+ *
+ * /see [AMD64 ABI Draft 0.99.6](https://refspecs.linuxbase.org/elf/x86_64-abi-0.99.pdf)
+ * 3.4 Process Initialization
+ */
+_start:
+    // 1. "the user code should mark the deepest stack frame by setting the
+    //    frame pointer to zero"
+    xor %rbp, %rbp
+
+    // 2. setting `_c_start` params. Ignoring auxiliary vector
+    // 2.1 argc, argv
+    pop %rdi         // argc -> %rdi
+    mov %rsp, %rsi   // argv -> %rsi
+
+    // 2.2 envp
+    // NOTE: calculating 8+8*argc+%rsp in %rax
+    mov %rdi, %rax   // argc      -> %rax
+    mov   $8, %rdx   // $8        -> %rdx
+    mul %rdx         // %rdx:%rax := %rax * %rdx
+    add %rsp, %rax   // %rax      := %rax + %rsp
+    add   $8, %rax   // %rax      += $8
+
+    // finally setting envp as the third param
+    mov %rax, %rdx   // envp -> %rdx
+
+    // 3. aligning the stack back
+    /* NOTE: %rsp needs to be 16-byte aligned and it'is guaranteed to be so at
+     *       process entry. But as we already have poped %rdi (8 bytes) we need
+     *       to align it again.                                               */
+    and $-16, %rsp
+
+    // 4. calling the _c_start
+    call _c_start
+
+    // syscalling exit
+    mov %rax, %rdi   // arg1 := result of _c_start
+    mov  $60, %rax   // sysno. See `<asm/unistd.h>`
+    syscall


### PR DESCRIPTION
See [AMD64 ABI Draft 0.99.6](https://refspecs.linuxbase.org/elf/x86_64-abi-0.99.pdf)